### PR TITLE
Removes unnecessary collection copies by using Collections#unmodifiable... instead of Immutable...#copyOf.

### DIFF
--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadata.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadata.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.crepecake.cache;
 import com.google.cloud.tools.crepecake.image.DuplicateLayerException;
 import com.google.cloud.tools.crepecake.image.ImageLayers;
 import com.google.cloud.tools.crepecake.image.LayerPropertyNotFoundException;
-import com.google.common.annotations.VisibleForTesting;
 
 // TODO: Change this to match the new format of CacheMetadataTemplate.
 /**

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadata.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadata.java
@@ -35,7 +35,6 @@ class CacheMetadata {
     layers.add(layer);
   }
 
-  @VisibleForTesting
   ImageLayers<CachedLayerWithMetadata> getLayers() {
     return layers;
   }

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTranslator.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTranslator.java
@@ -77,7 +77,7 @@ public class CacheMetadataTranslator {
   static CacheMetadataTemplate toTemplate(CacheMetadata cacheMetadata) {
     CacheMetadataTemplate template = new CacheMetadataTemplate();
 
-    for (CachedLayerWithMetadata cachedLayerWithMetadata : cacheMetadata.getLayers().asList()) {
+    for (CachedLayerWithMetadata cachedLayerWithMetadata : cacheMetadata.getLayers().getLayers()) {
       LayerMetadata layerMetadata = cachedLayerWithMetadata.getMetadata();
 
       CacheMetadataLayerObjectTemplate layerObjectTemplate =

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/Image.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/Image.java
@@ -16,8 +16,7 @@
 
 package com.google.cloud.tools.crepecake.image;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,24 +33,24 @@ public class Image {
   /** Initial command to run when running the image. */
   private List<String> entrypoint;
 
-  public ImmutableMap<String, String> getEnvironmentMap() {
-    return ImmutableMap.copyOf(environmentMap);
+  public Map<String, String> getEnvironmentMap() {
+    return Collections.unmodifiableMap(environmentMap);
   }
 
   public void setEnvironmentVariable(String name, String value) {
     environmentMap.put(name, value);
   }
 
-  public ImmutableList<String> getEntrypoint() {
-    return ImmutableList.copyOf(entrypoint);
+  public List<String> getEntrypoint() {
+    return Collections.unmodifiableList(entrypoint);
   }
 
   public void setEntrypoint(List<String> entrypoint) {
     this.entrypoint = entrypoint;
   }
 
-  public ImmutableList<Layer> getLayers() {
-    return layers.asList();
+  public List<Layer> getLayers() {
+    return layers.getLayers();
   }
 
   public void addLayer(Layer layer) throws DuplicateLayerException, LayerPropertyNotFoundException {

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/ImageLayers.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/ImageLayers.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.crepecake.image;
 
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,9 +31,9 @@ public class ImageLayers<T extends Layer> {
   /** Keeps track of the layers already added. */
   private final Set<DescriptorDigest> layerDigests = new HashSet<>();
 
-  /** Returns an immutable copy of the image layers. */
-  public ImmutableList<T> asList() {
-    return ImmutableList.copyOf(layers);
+  /** Returns a read-only view of the image layers. */
+  public List<T> getLayers() {
+    return Collections.unmodifiableList(layers);
   }
 
   /**

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/json/V21ManifestTemplate.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/json/V21ManifestTemplate.java
@@ -19,8 +19,8 @@ package com.google.cloud.tools.crepecake.image.json;
 import com.google.cloud.tools.crepecake.image.DescriptorDigest;
 import com.google.cloud.tools.crepecake.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -86,8 +86,8 @@ public class V21ManifestTemplate extends ManifestTemplate {
     return schemaVersion;
   }
 
-  public ImmutableList<LayerObjectTemplate> getFsLayers() {
-    return ImmutableList.copyOf(fsLayers);
+  public List<LayerObjectTemplate> getFsLayers() {
+    return Collections.unmodifiableList(fsLayers);
   }
 
   @VisibleForTesting

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/json/V22ManifestTemplate.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/image/json/V22ManifestTemplate.java
@@ -19,8 +19,8 @@ package com.google.cloud.tools.crepecake.image.json;
 import com.google.cloud.tools.crepecake.image.DescriptorDigest;
 import com.google.cloud.tools.crepecake.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -102,8 +102,8 @@ public class V22ManifestTemplate extends ManifestTemplate {
     return schemaVersion;
   }
 
-  public ImmutableList<LayerObjectTemplate> getLayers() {
-    return ImmutableList.copyOf(layers);
+  public List<LayerObjectTemplate> getLayers() {
+    return Collections.unmodifiableList(layers);
   }
 
   public void setContainerConfiguration(long size, DescriptorDigest digest) {

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/json/ErrorResponseTemplate.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/json/ErrorResponseTemplate.java
@@ -17,8 +17,8 @@
 package com.google.cloud.tools.crepecake.registry.json;
 
 import com.google.cloud.tools.crepecake.json.JsonTemplate;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -42,7 +42,7 @@ public class ErrorResponseTemplate extends JsonTemplate {
 
   private final List<ErrorEntryTemplate> errors = new ArrayList<>();
 
-  public ImmutableList<ErrorEntryTemplate> getErrors() {
-    return ImmutableList.copyOf(errors);
+  public List<ErrorEntryTemplate> getErrors() {
+    return Collections.unmodifiableList(errors);
   }
 }

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTest.java
@@ -49,6 +49,6 @@ public class CacheMetadataTest {
     CacheMetadata cacheMetadata = new CacheMetadata();
     cacheMetadata.addLayer(mockLayer);
 
-    Assert.assertThat(cacheMetadata.getLayers().asList(), CoreMatchers.hasItem(mockLayer));
+    Assert.assertThat(cacheMetadata.getLayers().getLayers(), CoreMatchers.hasItem(mockLayer));
   }
 }

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTranslatorTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheMetadataTranslatorTest.java
@@ -89,7 +89,7 @@ public class CacheMetadataTranslatorTest {
 
     CacheMetadata cacheMetadata = CacheMetadataTranslator.fromTemplate(metadataTemplate, fakePath);
 
-    List<CachedLayerWithMetadata> layers = cacheMetadata.getLayers().asList();
+    List<CachedLayerWithMetadata> layers = cacheMetadata.getLayers().getLayers();
 
     // Checks that the base layer was translated correctly.
     CachedLayerWithMetadata baseLayer = layers.get(0);

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/cache/CacheTest.java
@@ -37,7 +37,7 @@ public class CacheTest {
     Path cacheDirectory = temporaryCacheDirectory.newFolder().toPath();
 
     Cache cache = Cache.init(cacheDirectory);
-    Assert.assertEquals(0, cache.getMetadata().getLayers().asList().size());
+    Assert.assertEquals(0, cache.getMetadata().getLayers().getLayers().size());
   }
 
   @Test
@@ -63,6 +63,6 @@ public class CacheTest {
     Files.copy(metadataJsonPath, cacheDirectory.resolve(CacheFiles.METADATA_FILENAME));
 
     Cache cache = Cache.init(cacheDirectory);
-    Assert.assertEquals(2, cache.getMetadata().getLayers().asList().size());
+    Assert.assertEquals(2, cache.getMetadata().getLayers().getLayers().size());
   }
 }

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/image/ImageLayersTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/image/ImageLayersTest.java
@@ -69,7 +69,7 @@ public class ImageLayersTest {
     imageLayers.add(mockReferenceLayer);
     imageLayers.add(mockDigestOnlyLayer);
 
-    Assert.assertThat(imageLayers.asList(), CoreMatchers.is(expectedLayers));
+    Assert.assertThat(imageLayers.getLayers(), CoreMatchers.is(expectedLayers));
   }
 
   @Test


### PR DESCRIPTION
For these cases changed where a private collection field is returned, there is no need to maintain immutability. A less-strict read-only view of the collections can be returned instead, so that no unnecessary copying is done.