### PR TITLE
Adds BlobChecker.

### DIFF
--- a/crepecake/src/integration-test/java/com/google/cloud/tools/crepecake/registry/BlobCheckerIntegrationTest.java
+++ b/crepecake/src/integration-test/java/com/google/cloud/tools/crepecake/registry/BlobCheckerIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.crepecake.registry;
+
+import com.google.cloud.tools.crepecake.image.DescriptorDigest;
+import com.google.cloud.tools.crepecake.image.json.V22ManifestTemplate;
+import java.io.IOException;
+import java.security.DigestException;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Integration tests for {@link BlobChecker}. */
+public class BlobCheckerIntegrationTest {
+
+  @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
+
+  @Test
+  public void testCheck_exists() throws IOException, RegistryException {
+    RegistryClient registryClient = new RegistryClient(null, "localhost:5000", "busybox");
+    V22ManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", V22ManifestTemplate.class);
+    DescriptorDigest blobDigest = manifestTemplate.getLayerDigest(0);
+
+    Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).getDigest());
+  }
+
+  @Test
+  public void testCheck_doesNotExist() throws IOException, RegistryException, DigestException {
+    RegistryClient registryClient = new RegistryClient(null, "localhost:5000", "busybox");
+    DescriptorDigest fakeBlobDigest =
+        DescriptorDigest.fromHash(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    Assert.assertEquals(null, registryClient.checkBlob(fakeBlobDigest));
+  }
+}

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheFiles.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/cache/CacheFiles.java
@@ -30,7 +30,7 @@ class CacheFiles {
   }
 
   /**
-   * Gets the file for a layer digest. The file is {@code <cache directory>/<layer hash>.tar.gz}.
+   * Gets the file for a layer digest. The file is {@code [cache directory]/[layer hash].tar.gz}.
    */
   static Path getLayerFile(Path cacheDirectory, DescriptorDigest layerDigest) {
     return cacheDirectory.resolve(layerDigest.getHash() + LAYER_FILE_EXTENSION);

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
@@ -42,18 +42,19 @@ public class Response {
     return httpResponse.getHeaders().getHeaderStringValues(headerName);
   }
 
-  /**
-   * @return the first {@code Content-Length} header, or {@code -1} if not found
-   * @throws NumberFormatException if the {@code Content-Length} header could not be parsed as a
-   *     number
-   */
+  /** @return the first {@code Content-Length} header, or {@code -1} if not found */
   public long getContentLength() throws NumberFormatException {
     String contentLengthHeader =
         httpResponse.getHeaders().getFirstHeaderStringValue(HttpHeaders.CONTENT_LENGTH);
     if (contentLengthHeader == null) {
       return -1;
     }
-    return Long.parseLong(contentLengthHeader);
+    try {
+      return Long.parseLong(contentLengthHeader);
+
+    } catch (NumberFormatException ex) {
+      return -1;
+    }
   }
 
   /** Gets the HTTP response body as a {@link Blob}. */

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
@@ -42,8 +42,12 @@ public class Response {
     return httpResponse.getHeaders().getHeaderStringValues(headerName);
   }
 
-  /** Gets the first {@code Content-Length} header, or {@code -1} if not found. */
-  public long getContentLength() {
+  /**
+   * @return the first {@code Content-Length} header, or {@code -1} if not found
+   * @throws NumberFormatException if the {@code Content-Length} header could not be parsed as a
+   *     number
+   */
+  public long getContentLength() throws NumberFormatException {
     String contentLengthHeader =
         httpResponse.getHeaders().getFirstHeaderStringValue(HttpHeaders.CONTENT_LENGTH);
     if (contentLengthHeader == null) {

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/http/Response.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.crepecake.http;
 import com.google.api.client.http.HttpResponse;
 import com.google.cloud.tools.crepecake.blob.Blob;
 import com.google.cloud.tools.crepecake.blob.Blobs;
+import com.google.common.net.HttpHeaders;
 import java.io.IOException;
 import java.util.List;
 
@@ -39,6 +40,16 @@ public class Response {
   /** Gets a header in the response. */
   public List<String> getHeader(String headerName) {
     return httpResponse.getHeaders().getHeaderStringValues(headerName);
+  }
+
+  /** Gets the first {@code Content-Length} header, or {@code -1} if not found. */
+  public long getContentLength() {
+    String contentLengthHeader =
+        httpResponse.getHeaders().getFirstHeaderStringValue(HttpHeaders.CONTENT_LENGTH);
+    if (contentLengthHeader == null) {
+      return -1;
+    }
+    return Long.parseLong(contentLengthHeader);
   }
 
   /** Gets the HTTP response body as a {@link Blob}. */

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
@@ -50,21 +50,14 @@ class BlobChecker implements RegistryEndpointProvider<BlobDescriptor> {
   /** @return the BLOB's content descriptor */
   @Override
   public BlobDescriptor handleResponse(Response response) throws RegistryErrorException {
-    try {
-      long contentLength = response.getContentLength();
-      if (contentLength < 0) {
-        throw new RegistryErrorExceptionBuilder(getActionDescription())
-            .addReason("Did not receive Content-Length header")
-            .build();
-      }
-
-      return new BlobDescriptor(contentLength, blobDigest);
-
-    } catch (NumberFormatException ex) {
-      throw new RegistryErrorExceptionBuilder(getActionDescription(), ex)
-          .addReason("Content-Length header was not a number")
+    long contentLength = response.getContentLength();
+    if (contentLength < 0) {
+      throw new RegistryErrorExceptionBuilder(getActionDescription())
+          .addReason("Did not receive Content-Length header")
           .build();
     }
+
+    return new BlobDescriptor(contentLength, blobDigest);
   }
 
   @Override

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
@@ -47,17 +47,24 @@ class BlobChecker implements RegistryEndpointProvider<BlobDescriptor> {
     this.blobDigest = blobDigest;
   }
 
-  /** @return the BLOB's size, if it exists, or {@code null} if it doesn't */
+  /** @return the BLOB's content descriptor */
   @Override
   public BlobDescriptor handleResponse(Response response) throws RegistryErrorException {
-    long contentLength = response.getContentLength();
-    if (contentLength < 0) {
-      throw new RegistryErrorExceptionBuilder(getActionDescription())
-          .addReason("Did not receive Content-Length header")
+    try {
+      long contentLength = response.getContentLength();
+      if (contentLength < 0) {
+        throw new RegistryErrorExceptionBuilder(getActionDescription())
+            .addReason("Did not receive Content-Length header")
+            .build();
+      }
+
+      return new BlobDescriptor(contentLength, blobDigest);
+
+    } catch (NumberFormatException ex) {
+      throw new RegistryErrorExceptionBuilder(getActionDescription(), ex)
+          .addReason("Content-Length header was not a number")
           .build();
     }
-
-    return new BlobDescriptor(contentLength, blobDigest);
   }
 
   @Override

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobChecker.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.crepecake.registry;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.tools.crepecake.blob.BlobDescriptor;
+import com.google.cloud.tools.crepecake.http.BlobHttpContent;
+import com.google.cloud.tools.crepecake.http.Response;
+import com.google.cloud.tools.crepecake.image.DescriptorDigest;
+import com.google.cloud.tools.crepecake.json.JsonTemplateMapper;
+import com.google.cloud.tools.crepecake.registry.json.ErrorEntryTemplate;
+import com.google.cloud.tools.crepecake.registry.json.ErrorResponseTemplate;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Checks if an image's BLOB exists on a registry, and retrieves its {@link BlobDescriptor} if it
+ * exists.
+ */
+class BlobChecker implements RegistryEndpointProvider<BlobDescriptor> {
+
+  private final RegistryEndpointProperties registryEndpointProperties;
+  private final DescriptorDigest blobDigest;
+
+  BlobChecker(RegistryEndpointProperties registryEndpointProperties, DescriptorDigest blobDigest) {
+    this.registryEndpointProperties = registryEndpointProperties;
+    this.blobDigest = blobDigest;
+  }
+
+  /** @return the BLOB's size, if it exists, or {@code null} if it doesn't */
+  @Override
+  public BlobDescriptor handleResponse(Response response) throws RegistryErrorException {
+    long contentLength = response.getContentLength();
+    if (contentLength < 0) {
+      throw new RegistryErrorExceptionBuilder(getActionDescription())
+          .addReason("Did not receive Content-Length header")
+          .build();
+    }
+
+    return new BlobDescriptor(contentLength, blobDigest);
+  }
+
+  @Override
+  public BlobDescriptor handleHttpResponseException(HttpResponseException httpResponseException)
+      throws RegistryErrorException, HttpResponseException {
+    if (httpResponseException.getStatusCode() != HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+      throw httpResponseException;
+    }
+
+    // Finds a BLOB_UNKNOWN error response code.
+    String errorContent = httpResponseException.getContent();
+    if (errorContent == null) {
+      // TODO: The Google HTTP client gives null content for HEAD requests. Make the content never be null, even for HEAD requests.
+      return null;
+    } else {
+      try {
+        ErrorResponseTemplate errorResponse =
+            JsonTemplateMapper.readJson(errorContent, ErrorResponseTemplate.class);
+        List<ErrorEntryTemplate> errors = errorResponse.getErrors();
+        if (errors.size() == 1) {
+          ErrorCodes errorCode = ErrorCodes.valueOf(errors.get(0).getCode());
+          if (errorCode.equals(ErrorCodes.BLOB_UNKNOWN)) {
+            return null;
+          }
+        }
+
+      } catch (IOException ex) {
+        throw new RegistryErrorExceptionBuilder(getActionDescription(), ex)
+            .addReason("Failed to parse registry error response body")
+            .build();
+      }
+    }
+
+    // BLOB_UNKNOWN was not found as a error response code.
+    throw httpResponseException;
+  }
+
+  @Override
+  public URL getApiRoute(String apiRouteBase) throws MalformedURLException {
+    return new URL(
+        apiRouteBase + registryEndpointProperties.getImageName() + "/blobs/" + blobDigest);
+  }
+
+  @Nullable
+  @Override
+  public BlobHttpContent getContent() {
+    return null;
+  }
+
+  @Override
+  public List<String> getAccept() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getHttpMethod() {
+    return HttpMethods.HEAD;
+  }
+
+  @Override
+  public String getActionDescription() {
+    return "check BLOB exists for "
+        + registryEndpointProperties.getServerUrl()
+        + "/"
+        + registryEndpointProperties.getImageName()
+        + " with digest "
+        + blobDigest;
+  }
+}

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobPuller.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/BlobPuller.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/** Pulls an image's blob (layer or container configuration). */
+/** Pulls an image's BLOB (layer or container configuration). */
 class BlobPuller implements RegistryEndpointProvider<Blob> {
 
   private final RegistryEndpointProperties registryEndpointProperties;

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/RegistryClient.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/RegistryClient.java
@@ -20,6 +20,7 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.tools.crepecake.blob.Blob;
+import com.google.cloud.tools.crepecake.blob.BlobDescriptor;
 import com.google.cloud.tools.crepecake.http.Authorization;
 import com.google.cloud.tools.crepecake.http.Connection;
 import com.google.cloud.tools.crepecake.http.Request;
@@ -83,6 +84,16 @@ public class RegistryClient {
     ManifestPusher manifestPusher =
         new ManifestPusher(registryEndpointProperties, manifestTemplate, imageTag);
     callRegistryEndpoint(manifestPusher);
+  }
+
+  /**
+   * @return the BLOB's {@link BlobDescriptor} if the BLOB exists on the registry, or {@code null}
+   *     if it doesn't
+   */
+  public BlobDescriptor checkBlob(DescriptorDigest blobDigest)
+      throws IOException, RegistryException {
+    BlobChecker blobChecker = new BlobChecker(registryEndpointProperties, blobDigest);
+    return callRegistryEndpoint(blobChecker);
   }
 
   /**

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/RegistryEndpointProvider.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/RegistryEndpointProvider.java
@@ -32,6 +32,15 @@ import javax.annotation.Nullable;
  */
 interface RegistryEndpointProvider<T> {
 
+  /** @return the HTTP method to send the request with */
+  String getHttpMethod();
+
+  /**
+   * @param apiRouteBase the registry's base URL (for example, {@code https://gcr.io/v2/})
+   * @return the registry endpoint URL
+   */
+  URL getApiRoute(String apiRouteBase) throws MalformedURLException;
+
   /** @return the {@link BlobHttpContent} to send as the request body */
   @Nullable
   BlobHttpContent getContent();
@@ -41,15 +50,6 @@ interface RegistryEndpointProvider<T> {
 
   /** Handles the response specific to the registry action. */
   T handleResponse(Response response) throws IOException, RegistryException;
-
-  /**
-   * @param apiRouteBase the registry's base URL (for example, {@code https://gcr.io/v2/})
-   * @return the registry endpoint URL
-   */
-  URL getApiRoute(String apiRouteBase) throws MalformedURLException;
-
-  /** @return the HTTP method to send the request with */
-  String getHttpMethod();
 
   /**
    * Handles an {@link HttpResponseException} that occurs.

--- a/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/json/ErrorResponseTemplate.java
+++ b/crepecake/src/main/java/com/google/cloud/tools/crepecake/registry/json/ErrorResponseTemplate.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.crepecake.registry.json;
 
 import com.google.cloud.tools.crepecake.json.JsonTemplate;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,5 +45,11 @@ public class ErrorResponseTemplate extends JsonTemplate {
 
   public List<ErrorEntryTemplate> getErrors() {
     return Collections.unmodifiableList(errors);
+  }
+
+  @VisibleForTesting
+  public ErrorResponseTemplate addError(ErrorEntryTemplate errorEntryTemplate) {
+    errors.add(errorEntryTemplate);
+    return this;
   }
 }

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/registry/AuthenticationMethodRetrieverTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/registry/AuthenticationMethodRetrieverTest.java
@@ -86,7 +86,7 @@ public class AuthenticationMethodRetrieverTest {
   }
 
   @Test
-  public void testHandleHttpResponseException_not401() throws RegistryErrorException {
+  public void testHandleHttpResponseException_invalidStatusCode() throws RegistryErrorException {
     Mockito.when(mockHttpResponseException.getStatusCode()).thenReturn(-1);
 
     try {

--- a/crepecake/src/test/java/com/google/cloud/tools/crepecake/registry/BlobCheckerTest.java
+++ b/crepecake/src/test/java/com/google/cloud/tools/crepecake/registry/BlobCheckerTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.crepecake.registry;
+
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.tools.crepecake.blob.BlobDescriptor;
+import com.google.cloud.tools.crepecake.blob.Blobs;
+import com.google.cloud.tools.crepecake.http.Response;
+import com.google.cloud.tools.crepecake.image.DescriptorDigest;
+import com.google.cloud.tools.crepecake.json.JsonTemplateMapper;
+import com.google.cloud.tools.crepecake.registry.json.ErrorEntryTemplate;
+import com.google.cloud.tools.crepecake.registry.json.ErrorResponseTemplate;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.DigestException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Tests for {@link BlobChecker}. */
+@RunWith(MockitoJUnitRunner.class)
+public class BlobCheckerTest {
+
+  @Mock private Response mockResponse;
+
+  private final RegistryEndpointProperties fakeRegistryEndpointProperties =
+      new RegistryEndpointProperties("someServerUrl", "someImageName");
+
+  private BlobChecker testBlobChecker;
+  private DescriptorDigest fakeDigest;
+
+  @Before
+  public void setUpFakes() throws DigestException {
+    fakeDigest =
+        DescriptorDigest.fromHash(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    testBlobChecker = new BlobChecker(fakeRegistryEndpointProperties, fakeDigest);
+  }
+
+  @Test
+  public void testHandleResponse() throws RegistryErrorException {
+    Mockito.when(mockResponse.getContentLength()).thenReturn(0L);
+    BlobDescriptor expectedBlobDescriptor = new BlobDescriptor(0, fakeDigest);
+
+    BlobDescriptor blobDescriptor = testBlobChecker.handleResponse(mockResponse);
+
+    Assert.assertEquals(expectedBlobDescriptor, blobDescriptor);
+  }
+
+  @Test
+  public void testHandleResponse_noContentLength() {
+    Mockito.when(mockResponse.getContentLength()).thenReturn(-1L);
+
+    try {
+      testBlobChecker.handleResponse(mockResponse);
+      Assert.fail("Should throw exception if Content-Length header is not present");
+
+    } catch (RegistryErrorException ex) {
+      Assert.assertThat(
+          ex.getMessage(), CoreMatchers.containsString("Did not receive Content-Length header"));
+    }
+  }
+
+  @Test
+  public void testHandleHttpResponseException() throws IOException, RegistryErrorException {
+    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockHttpResponseException.getStatusCode())
+        .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+
+    ErrorResponseTemplate emptyErrorResponseTemplate =
+        new ErrorResponseTemplate()
+            .addError(new ErrorEntryTemplate(ErrorCodes.BLOB_UNKNOWN.name(), "some message"));
+    Mockito.when(mockHttpResponseException.getContent())
+        .thenReturn(Blobs.writeToString(JsonTemplateMapper.toBlob(emptyErrorResponseTemplate)));
+
+    BlobDescriptor blobDescriptor =
+        testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+
+    Assert.assertNull(blobDescriptor);
+  }
+
+  @Test
+  public void testHandleHttpResponseException_hasOtherErrors()
+      throws IOException, RegistryErrorException {
+    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockHttpResponseException.getStatusCode())
+        .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+
+    ErrorResponseTemplate emptyErrorResponseTemplate =
+        new ErrorResponseTemplate()
+            .addError(new ErrorEntryTemplate(ErrorCodes.BLOB_UNKNOWN.name(), "some message"))
+            .addError(new ErrorEntryTemplate(ErrorCodes.MANIFEST_UNKNOWN.name(), "some message"));
+    Mockito.when(mockHttpResponseException.getContent())
+        .thenReturn(Blobs.writeToString(JsonTemplateMapper.toBlob(emptyErrorResponseTemplate)));
+
+    try {
+      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      Assert.fail("Non-BLOB_UNKNOWN errors should not be handled");
+
+    } catch (HttpResponseException ex) {
+      Assert.assertEquals(mockHttpResponseException, ex);
+    }
+  }
+
+  @Test
+  public void testHandleHttpResponseException_notBlobUnknown()
+      throws IOException, RegistryErrorException {
+    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockHttpResponseException.getStatusCode())
+        .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+
+    ErrorResponseTemplate emptyErrorResponseTemplate = new ErrorResponseTemplate();
+    Mockito.when(mockHttpResponseException.getContent())
+        .thenReturn(Blobs.writeToString(JsonTemplateMapper.toBlob(emptyErrorResponseTemplate)));
+
+    try {
+      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      Assert.fail("Non-BLOB_UNKNOWN errors should not be handled");
+
+    } catch (HttpResponseException ex) {
+      Assert.assertEquals(mockHttpResponseException, ex);
+    }
+  }
+
+  @Test
+  public void testHandleHttpResponseException_invalidStatusCode() throws RegistryErrorException {
+    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockHttpResponseException.getStatusCode()).thenReturn(-1);
+
+    try {
+      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      Assert.fail("Non-404 status codes should not be handled");
+
+    } catch (HttpResponseException ex) {
+      Assert.assertEquals(mockHttpResponseException, ex);
+    }
+  }
+
+  @Test
+  public void testGetApiRoute() throws MalformedURLException {
+    Assert.assertEquals(
+        new URL("http://someApiBase/someImageName/blobs/" + fakeDigest),
+        testBlobChecker.getApiRoute("http://someApiBase/"));
+  }
+
+  @Test
+  public void testGetContent() {
+    Assert.assertNull(testBlobChecker.getContent());
+  }
+
+  @Test
+  public void testGetAccept() {
+    Assert.assertEquals(0, testBlobChecker.getAccept().size());
+  }
+
+  @Test
+  public void testGetActionDescription() {
+    Assert.assertEquals(
+        "check BLOB exists for someServerUrl/someImageName with digest " + fakeDigest,
+        testBlobChecker.getActionDescription());
+  }
+
+  @Test
+  public void testGetHttpMethod() {
+    Assert.assertEquals("HEAD", testBlobChecker.getHttpMethod());
+  }
+}


### PR DESCRIPTION
Step 5 of #59 .

The `BlobChecker` is an interface to the registry endpoint for checking if a BLOB exists on a registry or not. This endpoint returns the size of the BLOB in the `Content-Length` header if the BLOB exists, or gives a `404 Not Found` error (with error details in the response body) if the BLOB doesn't exist.

See also https://docs.docker.com/registry/spec/api/#existing-layers